### PR TITLE
Updated `defaultdict` 'solution' to remove lambda.

### DIFF
--- a/collections.rst
+++ b/collections.rst
@@ -68,8 +68,7 @@ share a solution using ``defaultdict``.
 .. code:: python
 
     import collections
-    tree = lambda: collections.defaultdict(tree)
-    some_dict = tree()
+    some_dict = collections.defaultdict(tree)
     some_dict['colours']['favourite'] = "yellow"
     # Works fine
 


### PR DESCRIPTION
Adding the lambda to this example introduces new concepts which weren't in the original example and, as far as I know, aren't required. Simplified this example.
