### PR TITLE
Update ternary_operators.rst

### DIFF
--- a/ternary_operators.rst
+++ b/ternary_operators.rst
@@ -43,6 +43,30 @@ is some sample code:
     print("Ali is ", fitness)
     # Output: Ali is fat
 
+This works simply because True == 1 and False == 0, and so can be done
+with lists in addition to tuples.
+
 The above example is not widely used and is generally disliked by
 Pythonistas for not being Pythonic. It is also easy to confuse where to
 put the true value and where to put the false value in the tuple.
+
+Another reason to avoid using a tupled ternery is that it results in
+both elements of the tuple being evaluated, whereas the if-else
+ternary operator does not.
+
+**Example:**
+
+.. code:: python
+
+    condition = True
+    print(2 if condition else 1/0)
+    #Output is 2
+
+    print((1/0, 2)[condition])
+    #ZeroDivisionError is raised
+    
+This happens because with the tupled ternary technique, the tuple is
+first built, then an index is found.  For the if-else ternary operator,
+it follows the normal if-else logic tree.  Thus, if one case could
+raise an exception based on the condition, or if either case is a
+computation-heavy method, using tuples is best avoided.


### PR DESCRIPTION
Added an important note regarding tupled ternary operators.  They're avoided not just because they're not Pythonic, but also because the tuple itself is evaluated before a condition is chosen, leading to potential exceptions, problems, or slowdown.