### PR TITLE
Better example of __slots__magic.rst

### DIFF
--- a/__slots__magic.rst
+++ b/__slots__magic.rst
@@ -19,7 +19,7 @@ of attributes. Here is an example with and without ``__slots__``:
 .. code:: python
 
     class MyClass(object):
-        def __init__(name, identifier):
+        def __init__(self, name, identifier):
             self.name = name
             self.identifier = identifier
             self.set_up()
@@ -31,7 +31,7 @@ of attributes. Here is an example with and without ``__slots__``:
 
     class MyClass(object):
         __slots__ = ['name', 'identifier']
-        def __init__(name, identifier):
+        def __init__(self, name, identifier):
             self.name = name
             self.identifier = identifier
             self.set_up()
@@ -43,3 +43,49 @@ technique.
 
 On a sidenote, you might want to give PyPy a try. It does all of these
 optimizations by default.
+
+
+Below you can see an example showing exact memory usage with and without ``__slots__`` done in IPython thanks to https://github.com/ianozsvald/ipython_memory_usage
+
+.. code:: python
+
+	Python 3.4.3 (default, Jun  6 2015, 13:32:34)
+	Type "copyright", "credits" or "license" for more information.
+
+	IPython 4.0.0 -- An enhanced Interactive Python.
+	?         -> Introduction and overview of IPython's features.
+	%quickref -> Quick reference.
+	help      -> Python's own help system.
+	object?   -> Details about 'object', use 'object??' for extra details.
+
+	In [1]: import ipython_memory_usage.ipython_memory_usage as imu
+
+	In [2]: imu.start_watching_memory()
+	In [2] used 0.0000 MiB RAM in 5.31s, peaked 0.00 MiB above current, total RAM usage 15.57 MiB
+
+	In [3]: %cat slots.py
+	class MyClass(object):
+		__slots__ = ['name', 'identifier']
+		def __init__(self, name, identifier):
+			self.name = name
+			self.identifier = identifier
+
+	num = 1024*256
+	x = [MyClass(1,1) for i in range(num)]
+	In [3] used 0.2305 MiB RAM in 0.12s, peaked 0.00 MiB above current, total RAM usage 15.80 MiB
+
+	In [4]: from slots import *
+	In [4] used 9.3008 MiB RAM in 0.72s, peaked 0.00 MiB above current, total RAM usage 25.10 MiB
+
+	In [5]: %cat noslots.py
+	class MyClass(object):
+		def __init__(self, name, identifier):
+			self.name = name
+			self.identifier = identifier
+
+	num = 1024*256
+	x = [MyClass(1,1) for i in range(num)]
+	In [5] used 0.1758 MiB RAM in 0.12s, peaked 0.00 MiB above current, total RAM usage 25.28 MiB
+
+	In [6]: from noslots import *
+	In [6] used 22.6680 MiB RAM in 0.80s, peaked 0.00 MiB above current, total RAM usage 47.95 MiB


### PR DESCRIPTION
Added an example that shows particular memory usages of examples with and without ``__slots__`` magic.
Also fixed missing ``self`` argument from ``__init__``.