### PR TITLE
Update global_&_return.rst

### DIFF
--- a/global_&_return.rst
+++ b/global_&_return.rst
@@ -110,7 +110,7 @@ Some try to solve this problem by *returning* a ``tuple``, ``list`` or ``dict`` 
     print(profile_data[1])
     # Output: 30
 
-But what many programmers don't know is that you can return two separate values as well. Let's take a look at an example so that you can better understand it:
+Or by more common convention:
 
 .. code:: python
 
@@ -119,11 +119,4 @@ But what many programmers don't know is that you can return two separate values 
         age = 30
         return name, age
 
-    name, age = profile()
-    print(name)
-    # Output: Danny
-
-    print(age)
-    # Output: 30
-
-This is a better way to do it along with returning ``tuples``, ``lists`` and ``dicts``. Don't use ``global`` keyword unless you know what you are doing. ``global`` might be a better option in a few cases but is not in most of them.
+This is a better way to do it along with returning ``lists`` and ``dicts``. Don't use ``global`` keyword unless you know what you are doing. ``global`` might be a better option in a few cases but is not in most of them.


### PR DESCRIPTION
When explaining multiple return values, it shows returning a tuple in a function, and then says you can "return separate values as well as well".  However, returning "separate values" is just a different way syntactically of returning a tuple.  To state that they are different would be inaccurate

    In [1]: def myfunc():
       ...:     return 'a', 1
       ...: 

    In [2]: type(myfunc())
    Out[2]: tuple

This can be seen even outside of functions:

    In [3]: a = 1,2

    In [4]: type(a)
    Out[4]: tuple

I'm debating whether I should keep ``name, age = profile()`` in, as it shows a good example of unpacking the results of a function, though unpacking itself isn't a specific function feature