### PR TITLE
Fix typo in collections.rst

### DIFF
--- a/collections.rst
+++ b/collections.rst
@@ -232,7 +232,7 @@ You can now see that we can access members of a tuple just by their
 name using a ``.``. Let's dissect it a little more. A named tuple has two
 required arguments. They are the tuple name and the tuple field\_names.
 In the above example our tuple name was 'Animal' and the tuple
-field\_names were 'name', 'age' and 'cat'. Namedtuple makes your tuples
+field\_names were 'name', 'age' and 'type'. Namedtuple makes your tuples
 **self-document**. You can easily understand what is going on by having
 a quick glance at your code. And as you are not bound to use integer
 indexes to access members of a tuple, it makes it more easy to maintain

--- a/coroutines.rst
+++ b/coroutines.rst
@@ -26,7 +26,7 @@ We then commonly use it in a ``for`` loop like this:
         print(i)
 
 It is fast and does not put a lot of pressure on memory because it
-**generates** the values on the fly rather then storing them in a list.
+**generates** the values on the fly rather than storing them in a list.
 Now, if we use ``yield`` in the above example, more generally, we get a
 coroutine. Coroutines consume values which are sent to it. A very basic
 example would be a ``grep`` alternative in Python:


### PR DESCRIPTION
In line 235, I guess the third field_names should be 'type'.