### PR TITLE
Fixed syntax error in Section 7.6.1

### DIFF
--- a/decorators.rst
+++ b/decorators.rst
@@ -368,10 +368,7 @@ us specify a logfile to output to.
     @logit(logfile='func2.log')
     def myfunc2():
         pass
-        
-    myfunc2():
-        pass
-        
+    
     myfunc2()
     # Output: myfunc2 was called
     # A file called func2.log now exists, with the above string


### PR DESCRIPTION
In the code example in Section 7.6.1, there were two function calls to myfunc2(), and the first call was syntactically incorrect.
This also caused the code example to not be syntax highlighted on the website.
I fixed the error, and the code should be highlighted now.