### PR TITLE
we don't need the wrap list(... )

### DIFF
--- a/map_filter.rst
+++ b/map_filter.rst
@@ -33,7 +33,7 @@ Here you go:
 .. code:: python
 
     items = [1, 2, 3, 4, 5]
-    squared = list(map(lambda x: x**2, items))
+    squared = map(lambda x: x**2, items)
 
 Most of the times we use lambdas with ``map`` so I did the same. Instead
 of a list of inputs we can even have a list of functions!
@@ -47,7 +47,7 @@ of a list of inputs we can even have a list of functions!
 
     funcs = [multiply, add]
     for i in range(5):
-        value = list(map(lambda x: x(i), funcs))
+        value = map(lambda x: x(i), funcs)
         print(value)
 
     # Output:
@@ -66,7 +66,7 @@ function returns true. Here is a short and concise example:
 .. code:: python
 
     number_list = range(-5, 5)
-    less_than_zero = list(filter(lambda x: x < 0, number_list))
+    less_than_zero = filter(lambda x: x < 0, number_list)
     print(less_than_zero)
 
     # Output: [-5, -4, -3, -2, -1]


### PR DESCRIPTION
we don't need the wrap list(... ), because map, filter returns list itself:
li = [1,2,3]
li1 = map( lambda x:x**2, li)
# type(li1) == list