### PR TITLE
Fixes #132, typo in the super() call

### DIFF
--- a/decorators.rst
+++ b/decorators.rst
@@ -429,7 +429,7 @@ will not be covered here).
         '''
         def __init__(self, email='admin@myproject.com', *args, **kwargs):
             self.email = email
-            super(logit, self).__init__(*args, **kwargs)
+            super(email_logit, self).__init__(*args, **kwargs)
             
         def notify(self):
             # Send an email to self.email


### PR DESCRIPTION
```python
class email_logit(logit):
    def __init__(...):
        ...
        super(logit, self).__init__(...)  # -> super(email_logit, self).__init__(...)
```