### PR TITLE
Remove superfluous reduce import

### DIFF
--- a/map_filter.rst
+++ b/map_filter.rst
@@ -100,7 +100,6 @@ Now let's try it with reduce:
 
 .. code:: python
 
-    from functools import reduce
     product = reduce( (lambda x, y: x * y), [1, 2, 3, 4] )
 
     # Output: 24


### PR DESCRIPTION
When I tried the reduce example in the REPL first omitted the import and found the example worked.