### PR TITLE
Add classes.rst and nesting to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,50 +26,37 @@ Moreover, if you want to add more content to this book then kindly submit a pull
 Table of Contents:
 ------------------
 1) Programmer tools
-
-- [Virtual Environment](virtual_environment.rst)
-- [Debugging](debugging.rst)
-- [Object introspection](object_introspection.rst)
-
+    - [Virtual Environment](virtual_environment.rst)
+    - [Debugging](debugging.rst)
+    - [Object introspection](object_introspection.rst)
 2) Syntax
-
-- [Exceptions](exceptions.rst)
-- [For - Else](for_-_else.rst)
-- [Ternary Operators](ternary_operators.rst)
-- [Global & Return](global_&_return.rst)
-- [Open function](open_function.rst)
-- [\*args and \*\*kwargs](args_and_kwargs.rst)
-- [Context managers](context_managers.rst)
-
+    - [Exceptions](exceptions.rst)
+    - [For - Else](for_-_else.rst)
+    - [Ternary Operators](ternary_operators.rst)
+    - [Global & Return](global_&_return.rst)
+    - [Open function](open_function.rst)
+    - [\*args and \*\*kwargs](args_and_kwargs.rst)
+    - [Context managers](context_managers.rst)
 3) Functional programming
-
-- [Enumerate](enumerate.rst)
-- [Lambdas](lambdas.rst)
-- [``set`` Data Structure](set_-_data_structure.rst)
-- [Map & Filter](map_filter.rst)
-- [Comprehensions](comprehensions.rst)
-
+    - [Enumerate](enumerate.rst)
+    - [Lambdas](lambdas.rst)
+    - [``set`` Data Structure](set_-_data_structure.rst)
+    - [Map & Filter](map_filter.rst)
+    - [Comprehensions](comprehensions.rst)
 4) Data structures
-
-- [Generators](generators.rst)
-- [Coroutines](coroutines.rst)
-
+    - [Generators](generators.rst)
+    - [Coroutines](coroutines.rst)
 5) Data types
-
-- [Collections](collections.rst)
-- [Mutation](mutation.rst)
-- [\_\_slots\_\_ Magic](__slots__magic.rst)
-
+    - [Collections](collections.rst)
+    - [Mutation](mutation.rst)
+    - [\_\_slots\_\_ Magic](__slots__magic.rst)
 6) Decorators
-
-- [What is a decorator?](decorators.rst)
-- [Function caching](function_caching.rst)
-
+    - [What is a decorator?](decorators.rst)
+    - [Function caching](function_caching.rst)
 7) Extras
-
-- [One Liners](one_liners.rst)
-- [Targeting Python 2+3](targeting_python_2_3.rst)
-- [Python C extensions](python_c_extension.rst)
+    - [One Liners](one_liners.rst)
+    - [Targeting Python 2+3](targeting_python_2_3.rst)
+    - [Python C extensions](python_c_extension.rst)
 
 Author:
 ------

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Table of Contents:
 4) Data structures
     - [Generators](generators.rst)
     - [Coroutines](coroutines.rst)
+    - [Classes](classes.rst)
 5) Data types
     - [Collections](collections.rst)
     - [Mutation](mutation.rst)


### PR DESCRIPTION
I noticed `classes.rst` are missing from the README, the second commit fixes that.

Another one introduces a nesting indentation for the Table of Content in README. Not sure if the original version without the indentation was intentional or not so please feel free to decline if it was.