### PR TITLE
Fix typos in output of getitem example

### DIFF
--- a/classes.rst
+++ b/classes.rst
@@ -200,12 +200,12 @@ Implementing **getitem** in a class allows its instances to use the []
         def __getitem__(self,i):
             return self.info[i]
 
-    foo = OldClass()
-    foo['title']
+    foo = GetTest()
+    foo['name']
     # Output: 'Yasoob'
 
     foo['number']
-    # Output: 36845124
+    # Output: 12345812
 
 Without the ``__getitem__`` method we would have got this error:
 


### PR DESCRIPTION
The getitem example was calling OldClass() instead of GetTest() and the output wasn't quite right.