### PR TITLE
Wrong variable name for shorthand ternary example

### DIFF
--- a/ternary_operators.rst
+++ b/ternary_operators.rst
@@ -95,7 +95,7 @@ This is helpful in case where you quickly want to check for the output of a func
 
 .. code:: python
 
-    >>> func_output = None
+    >>> output = None
     >>> msg = output or "No data returned"
     >>> print(msg)
     No data returned


### PR DESCRIPTION
Hi!
At the bottom we need to use `output` variable, not `func_output`.
Otherwise, code won't work.
Cheers!