### PR TITLE
Fix the contextmanager example

### DIFF
--- a/context_managers.rst
+++ b/context_managers.rst
@@ -153,8 +153,10 @@ Let's see a basic, useless example:
     @contextmanager
     def open_file(name):
         f = open(name, 'w')
-        yield f
-        f.close()
+        try:
+            yield f
+        finally:
+            f.close()
 
 Okay! This way of implementing Context Managers appear to be more
 intuitive and easy. However, this method requires some knowledge about


### PR DESCRIPTION
In the original example, if an exception occurs in the block, the generator (1) re-raises this exception (2) exits without executing the codes after "yield". In other words, the codes after "yield" are not equivalent to the "__exit__" method.

The official doc suggests we use try...finally... to mimic the behavior of "__exit__":  https://docs.python.org/3/library/contextlib.html#contextlib.contextmanager