### PR TITLE
Add func call to Nesting a Decorator Within a Function

### DIFF
--- a/decorators.rst
+++ b/decorators.rst
@@ -354,6 +354,7 @@ us specify a logfile to output to.
                 with open(logfile, 'a') as opened_file:
                     # Now we log to the specified logfile
                     opened_file.write(log_string + '\n')
+                return func(*args, **kwargs)
             return wrapped_function
         return logging_decorator
 


### PR DESCRIPTION
'Nesting a Decorator Within a Function' code does not ever actually call the func,
so this commit adds execution and returns the wrapped function result when tagged with decorator.