### PR TITLE
A simple fix for cell value error.

### DIFF
--- a/map_filter.rst
+++ b/map_filter.rst
@@ -47,7 +47,7 @@ of a list of inputs we can even have a list of functions!
 
     funcs = [multiply, add]
     for i in range(5):
-        value = list(map(lambda x: x(i), funcs))
+        value = list(map(lambda x, y=i: x(y), funcs))
         print(value)
 
     # Output:


### PR DESCRIPTION
Line 50 causes a PyLint error: `[cell-var-from-loop] Cell value i defined in loop`. 
Here is a simple fix: `value = list(map(lambda x, y=i: x(y), funcs))`